### PR TITLE
fix(app): default window size + min window size

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -15,8 +15,10 @@ if (require('electron-squirrel-startup')) {
 const createWindow = async (): Promise<void> => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    height: 600,
-    width: 800,
+    height: 800,
+    width: 1200,
+    minHeight: 600,
+    minWidth: 960,
     webPreferences: {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixing the window size

- **What is the current behavior?** (You can also link to an open issue here)

The window size was small by default

- **What is the new behavior (if this is a feature change)?**

The default window size is bigger and now there is a minimum size

- **Other information**:
