### PR TITLE
fix(app): updating message time format

### DIFF
--- a/packages/app/src/front/views/ListView.tsx
+++ b/packages/app/src/front/views/ListView.tsx
@@ -14,6 +14,15 @@ import { LogCell } from '../components/grid/LogCell'
 const cols: ColDef<FsdtServerMessage>[] = [
   { headerName: 'Source', field: 'source', flex: 1, resizable: true },
   {
+    headerName: 'Time',
+    flex: 2,
+    field: 'data.timestamp',
+    resizable: true,
+    getQuickFilterText: () => '',
+    cellRenderer: ({ value }: { value: string }) => new Date(value).toLocaleTimeString(),
+  },
+  { headerName: 'Level', field: 'data.level', flex: 1, resizable: true },
+  {
     headerName: 'Content',
     field: 'data.content',
     cellRenderer: LogCell,
@@ -21,8 +30,6 @@ const cols: ColDef<FsdtServerMessage>[] = [
     autoHeight: true,
     resizable: true,
   },
-  { headerName: 'Time', flex: 2, field: 'data.timestamp', resizable: true, getQuickFilterText: () => '' },
-  { headerName: 'Level', field: 'data.level', flex: 1, resizable: true },
   { headerName: 'Tag', field: 'data.tag', flex: 1, resizable: true },
 ]
 

--- a/packages/core/utils/messageFactory.ts
+++ b/packages/core/utils/messageFactory.ts
@@ -13,7 +13,7 @@ export function createSourceLog(level: LogLevel, content: Any): FsdtMessage<Fsdt
     type: EventType.LOG,
     data: {
       content,
-      timestamp: new Date().toUTCString(),
+      timestamp: new Date().toISOString(),
       level,
     },
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixing format used for logs

- **What is the current behavior?** (You can also link to an open issue here)

Default date format for message was UTC

- **What is the new behavior (if this is a feature change)?**

Replacing the default format by the ISOFormat
The application now just show the time of the message

- **Other information**:
