### PR TITLE
fix(sdk): reconnection + message queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ type FsdtServerConfig = {
   useConsole?: boolean // If true, it displays logs in the default console in addition to FSDT console
 
   disable?: boolean // Disable the connection with the FSDT console (recommended in production)
+
+  printErrors?: boolean // Print the errors (connection errors, ...) (it's false by default)
 }
 ```
 

--- a/packages/app/src/front/App.tsx
+++ b/packages/app/src/front/App.tsx
@@ -19,6 +19,10 @@ getPort().then((port) => {
   logger.onLogReceived((message) => {
     useMessageStore.getState().addMessage(message)
   })
+
+  logger.onBatchLogsReceived((messages) => {
+    useMessageStore.getState().addMessages(messages)
+  })
 })
 
 getAppVersion().then((version) => {

--- a/packages/app/src/front/stores/messageStore.ts
+++ b/packages/app/src/front/stores/messageStore.ts
@@ -6,6 +6,7 @@ interface MessageState {
   sources: string[]
   tags: string[]
   addMessage: (message: FsdtServerMessage<FsdtLogMessageContent>) => void
+  addMessages: (messages: FsdtServerMessage<FsdtLogMessageContent>[]) => void
   clearMessages: () => void
 }
 
@@ -24,6 +25,20 @@ export const useMessageStore = create<MessageState>((set) => ({
         newTags.push(message.data.tag)
       }
       return { messages: [...state.messages, message], sources: newSources, tags: newTags }
+    }),
+  addMessages: (messages) =>
+    set((state) => {
+      const newSources = [...state.sources]
+      const newTags = [...state.tags]
+      messages.forEach((message) => {
+        if (!newSources.includes(message.source)) {
+          newSources.push(message.source)
+        }
+        if (!newTags.includes(message.data.tag) && message.data.tag) {
+          newTags.push(message.data.tag)
+        }
+      })
+      return { messages: [...state.messages, ...messages], sources: newSources, tags: newTags }
     }),
   clearMessages: () => set({ messages: [] }),
 }))

--- a/packages/app/src/server/connection/ConnectionManager.ts
+++ b/packages/app/src/server/connection/ConnectionManager.ts
@@ -1,51 +1,79 @@
-import { ConnectionType } from "@fullstack-devtool/core";
-import { FsdtConnection } from "./FsdtConnection";
+import {
+  createServerLog,
+  EventType,
+  FsdtLogMessageContent,
+  FsdtServerMessage,
+  safeJsonStringify,
+} from '@fullstack-devtool/core'
+import { FsdtConnection } from './FsdtConnection'
+import { sendErrorMessage } from '../utils/sendMessage'
+import { parseMessage } from '../utils/parseMessage'
+import { getLogId } from '../utils/getLogId'
 
-class ConnectionManager {
-  private _monitor: FsdtConnection | null = null;
-  private _sources: FsdtConnection[] = [];
+export class ConnectionManager {
+  private _monitor: FsdtConnection | null = null
+  private _sources: FsdtConnection[] = []
+  private _messageQueue: FsdtServerMessage[] = []
 
   register(connection: FsdtConnection) {
-    const type = connection.type;
-    if (type === ConnectionType.MONITOR) {
+    if (connection.isMonitor()) {
       if (this._monitor) {
-        this._monitor.connection.close();
+        this._monitor.connection.close()
       }
-      this._monitor = connection;
-    } else if (type === ConnectionType.SOURCE) {
-      this._sources.push(connection);
+      this._monitor = connection
+      this.flushMessageQueue()
+    } else if (connection.isSource()) {
+      this._sources.push(connection)
     }
+    this.addListeners(connection)
   }
 
   unregister(connection: FsdtConnection) {
-    connection.connection.close();
+    connection.connection.close()
 
     if (this._monitor === connection) {
-      this._monitor = null;
+      this._monitor = null
     } else {
-      const sourceToRemove = this._sources.find(
-        (source) => source === connection
-      );
-      if (!sourceToRemove) throw new Error("Source not found");
+      const sourceToRemove = this._sources.find((source) => source === connection)
+      if (!sourceToRemove) throw new Error('Source not found')
 
-      this._sources = this._sources.filter((source) => source !== connection);
+      this._sources = this._sources.filter((source) => source !== connection)
     }
   }
 
-  getAll() {
-    return {
-      monitor: this._monitor,
-      sources: this._sources,
-    };
+  private sendMessageOrEnqueue(connection: FsdtConnection, data: FsdtLogMessageContent) {
+    const message = createServerLog(connection.name, data, getLogId())
+    if (!this._monitor) {
+      this._messageQueue.push(message)
+      return
+    }
+    this._monitor.connection.send(safeJsonStringify(message))
   }
 
-  get monitor() {
-    return this._monitor;
+  private flushMessageQueue() {
+    this._monitor.connection.send(safeJsonStringify(this._messageQueue))
+    this._messageQueue = []
   }
 
-  get sources() {
-    return this._sources;
+  private addListeners(connection: FsdtConnection) {
+    // Message handler
+    connection.connection.on('message', (message) => {
+      try {
+        const { type, data } = parseMessage(message)
+
+        // Send the log to the monitor
+        if (type === EventType.LOG) {
+          this.sendMessageOrEnqueue(connection, data)
+        }
+      } catch (error) {
+        // Send error message to the source
+        sendErrorMessage(connection.connection, error.message)
+      }
+    })
+
+    // Close handler
+    connection.connection.on('close', () => {
+      this.unregister(connection)
+    })
   }
 }
-
-export default new ConnectionManager();

--- a/packages/app/src/server/connection/FsdtConnection.ts
+++ b/packages/app/src/server/connection/FsdtConnection.ts
@@ -1,22 +1,30 @@
-import { ConnectionType } from "@fullstack-devtool/core";
-import { WebSocket } from "ws";
+import { ConnectionType } from '@fullstack-devtool/core'
+import { WebSocket } from 'ws'
 
 export class FsdtConnection {
   constructor(
     private _connection: WebSocket,
     private _type: ConnectionType,
-    private _name: string = ""
+    private _name: string = ''
   ) {}
 
   get connection() {
-    return this._connection;
+    return this._connection
   }
 
   get name() {
-    return this._name;
+    return this._name
   }
 
   get type() {
-    return this._type;
+    return this._type
+  }
+
+  isMonitor() {
+    return this._type === ConnectionType.MONITOR
+  }
+
+  isSource() {
+    return this._type === ConnectionType.SOURCE
   }
 }

--- a/packages/app/src/server/utils/sendMessage.ts
+++ b/packages/app/src/server/utils/sendMessage.ts
@@ -1,29 +1,8 @@
 /**
  * This file aims to contain all the functions that send messages to the connected clients (monitor or source)
  */
-import {
-  createErrorMessage,
-  createServerLog,
-  FsdtLogMessageContent,
-  FsdtServerMessage,
-  safeJsonStringify,
-} from '@fullstack-devtool/core'
-import { FsdtConnection } from '../connection/FsdtConnection'
+import { createErrorMessage, safeJsonStringify } from '@fullstack-devtool/core'
 import { WebSocket } from 'ws'
-import { getLogId } from './getLogId'
-
-export function sendServerToMonitorMessage(
-  monitor: FsdtConnection,
-  source: FsdtConnection,
-  data: FsdtLogMessageContent
-): void {
-  if (!monitor) {
-    throw new Error('You should connect a monitor before sending a message')
-  }
-
-  const message: FsdtServerMessage = createServerLog(source.name, data, getLogId())
-  monitor.connection.send(safeJsonStringify(message))
-}
 
 export function sendErrorMessage(connection: WebSocket, error: string): void {
   const errorMessage = createErrorMessage(error)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -69,6 +69,8 @@ type FsdtServerConfig = {
   useConsole?: boolean; // If true, it displays logs in the default console in addition to FSDT console
 
   disable?: boolean; // Disable the connection with the FSDT console (recommended in production)
+
+  printErrors?: boolean; // Print the errors (connection errors, ...) (it's false by default)
 };
 ```
 

--- a/packages/sdk/src/types/config.ts
+++ b/packages/sdk/src/types/config.ts
@@ -4,4 +4,5 @@ export type FsdtServerConfig = {
   connectionType?: 'source' | 'monitor';
   useConsole?: boolean;
   disable?: boolean;
+  printErrors?: boolean;
 };

--- a/packages/sdk/src/types/listeners.ts
+++ b/packages/sdk/src/types/listeners.ts
@@ -6,3 +6,7 @@ import {
 export type OnLogReceived = (
   message: FsdtServerMessage<FsdtLogMessageContent>
 ) => void;
+
+export type OnBatchLogsReceived = (
+  messages: FsdtServerMessage<FsdtLogMessageContent>[]
+) => void;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Fixed sdk reconnection (The sdk tried to reconnect exponentially due to the timeout that wasn't cleared when a new one was created)
- Added a queue in the server side to send the logs once the monitor is connected.
- Added the possibility to send a batch of messages to avoid sending too many messages when the monitor is just connected